### PR TITLE
[HACK] Add support for media browsing

### DIFF
--- a/custom_components/media_player_template/manifest.json
+++ b/custom_components/media_player_template/manifest.json
@@ -5,6 +5,6 @@
     "issue_tracker": "https://github.com/Sennevds/media_player.template/issues",
     "requirements": [],
     "dependencies": [],
-    "after_dependencies": ["template"],
+    "after_dependencies": ["kodi", "template"],
     "codeowners": ["@Sennevds"]
   }


### PR DESCRIPTION
This adds "support" for doing media browsing via the template card. Right now this only supports kodi, but it may be possible to do other media browsing as well.

this works with two pieces of info:

* browse_media_domain: currently only "kodi"
* browse_media_conf_entry: this is unique to every users install, you can find it in the URL when filtering by the kodi integration:
```https://<YOUR_INSTALL>/config/entities?historyBack=1&config_entry=<YOUR_BROWSER_MEDIA_CONF_ENTRY>```

I really don't think this is a long term solution to this problem, and it really seems like some work needs to be done in home assistant to let items outside of the media browser components work with this feature. I'm primarily adding this with the intention that maybe someone will be able to build on this and come up with a better solution. 

Ideally, we should also be able to execute an action right before browsing the media, like changing inputs. likely this wouldn't be hard with this hack. 
