### PR TITLE
Modernize the integration

### DIFF
--- a/custom_components/media_player_template/media_player.py
+++ b/custom_components/media_player_template/media_player.py
@@ -502,7 +502,11 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
             self._attr_is_volume_muted = mute
             self.async_write_ha_state()
         if script := self._action_scripts.get(CONF_MUTE_ACTION):
-            await self.async_run_script(script, context=self._context)
+            await self.async_run_script(
+                script,
+                run_variables={"is_muted": mute},
+                context=self._context,
+            )
 
     async def async_media_play(self):
         """Fire the play action."""

--- a/custom_components/media_player_template/media_player.py
+++ b/custom_components/media_player_template/media_player.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_ENTITY_PICTURE_TEMPLATE,
     CONF_ICON_TEMPLATE,
+    CONF_STATE,
     CONF_UNIQUE_ID,
     CONF_VALUE_TEMPLATE,
 )
@@ -162,7 +163,7 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
         name = self._attr_name
 
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
-        self._template = config[CONF_VALUE_TEMPLATE]
+        self._template = config[CONF_STATE]
 
         self._attr_supported_features = MediaPlayerEntityFeature(0)
         for action_id, supported_feature in (

--- a/custom_components/media_player_template/media_player.py
+++ b/custom_components/media_player_template/media_player.py
@@ -79,7 +79,7 @@ CONF_VOLUME_UP_ACTION = "volume_up"
 MEDIA_PLAYER_SCHEMA = vol.Schema(
     {
         vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-        vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
+        vol.Optional(ATTR_FRIENDLY_NAME): cv.template,
         vol.Optional(CONF_ALBUM_ART_TEMPLATE): cv.template,
         vol.Optional(CONF_ALBUM_TEMPLATE): cv.template,
         vol.Optional(CONF_ARTIST_TEMPLATE): cv.template,
@@ -140,6 +140,7 @@ async def async_setup_platform(
         None,
         async_add_entities,
         discovery_info,
+        {},
     )
 
 

--- a/custom_components/media_player_template/media_player.py
+++ b/custom_components/media_player_template/media_player.py
@@ -2,24 +2,27 @@
 Template for media-player
 https://github.com/Sennevds/media_player.template
 """
+
 import logging
 
-import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
 import voluptuous as vol
+
 from homeassistant.components.media_player import (
+    DEVICE_CLASSES_SCHEMA,
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
     ENTITY_ID_FORMAT,
-    PLATFORM_SCHEMA,
+    PLATFORM_SCHEMA as MEDIA_PLAYER_PLATFORM_SCHEMA,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
+    MediaType,
 )
-from homeassistant.components.template.const import (
-    CONF_AVAILABILITY_TEMPLATE,
-    DOMAIN,
-    PLATFORMS,
+from homeassistant.components.template import DOMAIN
+from homeassistant.components.template.helpers import async_setup_template_platform
+from homeassistant.components.template.template_entity import (
+    TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY,
+    TemplateEntity,
 )
-from homeassistant.components.template.template_entity import TemplateEntity
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
@@ -28,441 +31,325 @@ from homeassistant.const import (
     CONF_ICON_TEMPLATE,
     CONF_UNIQUE_ID,
     CONF_VALUE_TEMPLATE,
-    STATE_UNKNOWN,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.reload import async_setup_reload_service
-from homeassistant.helpers.script import Script
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
-_VALID_STATES = [
-    MediaPlayerState.ON,
-    MediaPlayerState.OFF,
-    "true",
-    "false",
-    MediaPlayerState.IDLE,
-    MediaPlayerState.PAUSED,
-    MediaPlayerState.PLAYING,
-]
-CONF_AVAILABILITY_TEMPLATE = "availability_template"
-CONF_MEDIAPLAYER = "media_players"
-ON_ACTION = "turn_on"
-OFF_ACTION = "turn_off"
-PLAY_ACTION = "play"
-STOP_ACTION = "stop"
-PAUSE_ACTION = "pause"
-NEXT_ACTION = "next"
-PREVIOUS_ACTION = "previous"
-VOLUME_UP_ACTION = "volume_up"
-VOLUME_DOWN_ACTION = "volume_down"
-MUTE_ACTION = "mute"
-CURRENT_SOURCE_TEMPLATE = "current_source_template"
+
+CONF_ALBUM_ART_TEMPLATE = "album_art_template"
+CONF_ALBUM_TEMPLATE = "album_template"
+CONF_ARTIST_TEMPLATE = "artist_template"
+CONF_CURRENT_IS_MUTED_TEMPLATE = "current_is_muted_template"
+CONF_CURRENT_POSITION_TEMPLATE = "current_position_template"
+CONF_CURRENT_SOUND_MODE_TEMPLATE = "current_sound_mode_template"
+CONF_CURRENT_SOURCE_TEMPLATE = "current_source_template"
+CONF_CURRENT_VOLUME_TEMPLATE = "current_volume_template"
 CONF_INPUTS = "inputs"
-TITLE_TEMPLATE = "title_template"
-ARTIST_TEMPLATE = "artist_template"
-ALBUM_TEMPLATE = "album_template"
-CURRENT_VOLUME_TEMPLATE = "current_volume_template"
-CURRENT_IS_MUTED_TEMPLATE = "current_is_muted_template"
-ALBUM_ART_TEMPLATE = "album_art_template"
-SET_VOLUME_ACTION = "set_volume"
-PLAY_MEDIA_ACTION = "play_media"
-MEDIA_CONTENT_TYPE_TEMPLATE = "media_content_type_template"
-MEDIA_IMAGE_URL_TEMPLATE = "media_image_url_template"
-MEDIA_IMAGE_URL_REMOTELY_ACCESSIBLE = "media_image_url_remotely_accessible"
-MEDIA_EPISODE_TEMPLATE = "media_episode_template"
-MEDIA_SEASON_TEMPLATE = "media_season_template"
-MEDIA_SERIES_TITLE_TEMPLATE = "media_series_title_template"
-MEDIA_ALBUM_ARTIST_TEMPLATE = "media_album_artist_template"
-SEEK_ACTION = "seek"
-CURRENT_POSITION_TEMPLATE = "current_position_template"
-MEDIA_DURATION_TEMPLATE = "media_duration_template"
-CURRENT_SOUND_MODE_TEMPLATE = "current_sound_mode_template"
+CONF_MEDIA_ALBUM_ARTIST_TEMPLATE = "media_album_artist_template"
+CONF_MEDIA_CONTENT_TYPE_TEMPLATE = "media_content_type_template"
+CONF_MEDIA_DURATION_TEMPLATE = "media_duration_template"
+CONF_MEDIA_EPISODE_TEMPLATE = "media_episode_template"
+CONF_MEDIA_IMAGE_URL_REMOTELY_ACCESSIBLE = "media_image_url_remotely_accessible"
+CONF_MEDIA_IMAGE_URL_TEMPLATE = "media_image_url_template"
+CONF_MEDIA_SEASON_TEMPLATE = "media_season_template"
+CONF_MEDIA_SERIES_TITLE_TEMPLATE = "media_series_title_template"
+CONF_MEDIAPLAYER = "media_players"
+CONF_MUTE_ACTION = "mute"
+CONF_NEXT_ACTION = "next"
+CONF_OFF_ACTION = "turn_off"
+CONF_ON_ACTION = "turn_on"
+CONF_PAUSE_ACTION = "pause"
+CONF_PLAY_ACTION = "play"
+CONF_PLAY_MEDIA_ACTION = "play_media"
+CONF_PREVIOUS_ACTION = "previous"
+CONF_SEEK_ACTION = "seek"
+CONF_SET_VOLUME_ACTION = "set_volume"
 CONF_SOUND_MODES = "sound_modes"
+CONF_STOP_ACTION = "stop"
+CONF_TITLE_TEMPLATE = "title_template"
+CONF_VOLUME_DOWN_ACTION = "volume_down"
+CONF_VOLUME_UP_ACTION = "volume_up"
 
 
 MEDIA_PLAYER_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_VALUE_TEMPLATE): cv.template,
-        vol.Optional(CONF_ICON_TEMPLATE): cv.template,
-        vol.Optional(CONF_DEVICE_CLASS): cv.string,
-        vol.Optional(CONF_UNIQUE_ID): cv.string,
-        vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
-        vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
-        vol.Optional(CURRENT_SOURCE_TEMPLATE): cv.template,
-        vol.Optional(ON_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(OFF_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(PLAY_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(STOP_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(PAUSE_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(NEXT_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(PREVIOUS_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(VOLUME_UP_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(VOLUME_DOWN_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(MUTE_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(CONF_INPUTS, default={}): {cv.string: cv.SCRIPT_SCHEMA},
-        vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
         vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-        vol.Optional(SET_VOLUME_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(PLAY_MEDIA_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(TITLE_TEMPLATE): cv.template,
-        vol.Optional(ARTIST_TEMPLATE): cv.template,
-        vol.Optional(ALBUM_TEMPLATE): cv.template,
-        vol.Optional(CURRENT_VOLUME_TEMPLATE): cv.template,
-        vol.Optional(CURRENT_IS_MUTED_TEMPLATE): cv.template,
-        vol.Optional(ALBUM_ART_TEMPLATE): cv.template,
-        vol.Optional(MEDIA_CONTENT_TYPE_TEMPLATE): cv.template,
-        vol.Optional(MEDIA_IMAGE_URL_TEMPLATE): cv.template,
-        vol.Optional(MEDIA_IMAGE_URL_REMOTELY_ACCESSIBLE): cv.boolean,
-        vol.Optional(MEDIA_EPISODE_TEMPLATE): cv.template,
-        vol.Optional(MEDIA_SEASON_TEMPLATE): cv.template,
-        vol.Optional(MEDIA_SERIES_TITLE_TEMPLATE): cv.template,
-        vol.Optional(MEDIA_ALBUM_ARTIST_TEMPLATE): cv.template,
-        vol.Optional(SEEK_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Optional(CURRENT_POSITION_TEMPLATE): cv.template,
-        vol.Optional(MEDIA_DURATION_TEMPLATE): cv.template,
+        vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
+        vol.Optional(CONF_ALBUM_ART_TEMPLATE): cv.template,
+        vol.Optional(CONF_ALBUM_TEMPLATE): cv.template,
+        vol.Optional(CONF_ARTIST_TEMPLATE): cv.template,
+        vol.Optional(CONF_CURRENT_IS_MUTED_TEMPLATE): cv.template,
+        vol.Optional(CONF_CURRENT_POSITION_TEMPLATE): cv.template,
+        vol.Optional(CONF_CURRENT_SOUND_MODE_TEMPLATE): cv.template,
+        vol.Optional(CONF_CURRENT_SOURCE_TEMPLATE): cv.template,
+        vol.Optional(CONF_CURRENT_VOLUME_TEMPLATE): cv.template,
+        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+        vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
+        vol.Optional(CONF_ICON_TEMPLATE): cv.template,
+        vol.Optional(CONF_INPUTS, default={}): {cv.string: cv.SCRIPT_SCHEMA},
+        vol.Optional(CONF_MEDIA_ALBUM_ARTIST_TEMPLATE): cv.template,
+        vol.Optional(CONF_MEDIA_CONTENT_TYPE_TEMPLATE): cv.template,
+        vol.Optional(CONF_MEDIA_DURATION_TEMPLATE): cv.template,
+        vol.Optional(CONF_MEDIA_EPISODE_TEMPLATE): cv.template,
+        vol.Optional(CONF_MEDIA_IMAGE_URL_REMOTELY_ACCESSIBLE): cv.boolean,
+        vol.Optional(CONF_MEDIA_IMAGE_URL_TEMPLATE): cv.template,
+        vol.Optional(CONF_MEDIA_SEASON_TEMPLATE): cv.template,
+        vol.Optional(CONF_MEDIA_SERIES_TITLE_TEMPLATE): cv.template,
+        vol.Optional(CONF_MUTE_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_NEXT_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_OFF_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_ON_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_PAUSE_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_PLAY_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_PLAY_MEDIA_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_PREVIOUS_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_SEEK_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_SET_VOLUME_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_SOUND_MODES, default={}): {cv.string: cv.SCRIPT_SCHEMA},
-        vol.Optional(CURRENT_SOUND_MODE_TEMPLATE): cv.template,
+        vol.Optional(CONF_STOP_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_TITLE_TEMPLATE): cv.template,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Required(CONF_VALUE_TEMPLATE): cv.template,
+        vol.Optional(CONF_VOLUME_DOWN_ACTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_VOLUME_UP_ACTION): cv.SCRIPT_SCHEMA,
     }
-)
+).extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY.schema)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+PLATFORM_SCHEMA = MEDIA_PLAYER_PLATFORM_SCHEMA.extend(
     {vol.Required(CONF_MEDIAPLAYER): cv.schema_with_slug_keys(MEDIA_PLAYER_SCHEMA)}
 )
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up platform."""
-
-    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
-    async_add_entities(await _async_create_entities(hass, config))
-
-
-async def _async_create_entities(hass, config):
-    """Set up entities."""
-    media_players = []
-
-    for device, device_config in config[CONF_MEDIAPLAYER].items():
-        friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
-        device_class = device_config.get(CONF_DEVICE_CLASS, device)
-        state_template = device_config[CONF_VALUE_TEMPLATE]
-        icon_template = device_config.get(CONF_ICON_TEMPLATE)
-        unique_id = device_config.get(CONF_UNIQUE_ID)
-        entity_picture_template = device_config.get(CONF_ENTITY_PICTURE_TEMPLATE)
-        availability_template = device_config.get(CONF_AVAILABILITY_TEMPLATE)
-        current_source_template = device_config.get(CURRENT_SOURCE_TEMPLATE)
-        on_action = device_config.get(ON_ACTION)
-        off_action = device_config.get(OFF_ACTION)
-        play_action = device_config.get(PLAY_ACTION)
-        stop_action = device_config.get(STOP_ACTION)
-        pause_action = device_config.get(PAUSE_ACTION)
-        next_action = device_config.get(NEXT_ACTION)
-        previous_action = device_config.get(PREVIOUS_ACTION)
-        volume_up_action = device_config.get(VOLUME_UP_ACTION)
-        volume_down_action = device_config.get(VOLUME_DOWN_ACTION)
-        mute_action = device_config.get(MUTE_ACTION)
-        input_templates = device_config[CONF_INPUTS]
-        title_template = device_config.get(TITLE_TEMPLATE)
-        artist_template = device_config.get(ARTIST_TEMPLATE)
-        album_template = device_config.get(ALBUM_TEMPLATE)
-        current_volume_template = device_config.get(CURRENT_VOLUME_TEMPLATE)
-        current_is_muted_template = device_config.get(CURRENT_IS_MUTED_TEMPLATE)
-        album_art_template = device_config.get(ALBUM_ART_TEMPLATE)
-        set_volume_action = device_config.get(SET_VOLUME_ACTION)
-        play_media_action = device_config.get(PLAY_MEDIA_ACTION)
-        media_content_type_template = device_config.get(MEDIA_CONTENT_TYPE_TEMPLATE)
-        media_image_url_template = device_config.get(MEDIA_IMAGE_URL_TEMPLATE)
-        media_image_url_remotely_accessible = device_config.get(MEDIA_IMAGE_URL_REMOTELY_ACCESSIBLE)
-        media_episode_template = device_config.get(MEDIA_EPISODE_TEMPLATE)
-        media_season_template = device_config.get(MEDIA_SEASON_TEMPLATE)
-        media_series_title_template = device_config.get(MEDIA_SERIES_TITLE_TEMPLATE)
-        media_album_artist_template = device_config.get(MEDIA_ALBUM_ARTIST_TEMPLATE)
-        seek_action = device_config.get(SEEK_ACTION)
-        current_position_template = device_config.get(CURRENT_POSITION_TEMPLATE)
-        media_duration_template = device_config.get(MEDIA_DURATION_TEMPLATE)
-        sound_mode_templates = device_config[CONF_SOUND_MODES]
-        current_sound_mode_template = device_config.get(CURRENT_SOUND_MODE_TEMPLATE)
-
-        media_players.append(
-            MediaPlayerTemplate(
-                hass,
-                device,
-                friendly_name,
-                device_class,
-                state_template,
-                icon_template,
-                unique_id,
-                entity_picture_template,
-                availability_template,
-                current_source_template,
-                on_action,
-                off_action,
-                play_action,
-                stop_action,
-                pause_action,
-                next_action,
-                previous_action,
-                volume_up_action,
-                volume_down_action,
-                mute_action,
-                input_templates,
-                title_template,
-                artist_template,
-                album_template,
-                current_volume_template,
-                current_is_muted_template,
-                album_art_template,
-                set_volume_action,
-                play_media_action,
-                media_content_type_template,
-                media_image_url_template,
-                media_image_url_remotely_accessible,
-                media_episode_template,
-                media_season_template,
-                media_series_title_template,
-                media_album_artist_template,
-                seek_action,
-                current_position_template,
-                media_duration_template,
-                sound_mode_templates,
-                current_sound_mode_template,
-            )
-        )
-    return media_players
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the template media player."""
+    await async_setup_template_platform(
+        hass,
+        MEDIA_PLAYER_DOMAIN,
+        config,
+        MediaPlayerTemplate,
+        None,
+        async_add_entities,
+        discovery_info,
+    )
 
 
 class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
     """Representation of a Template Media player."""
 
+    _attr_should_poll = False
+    _entity_id_format = ENTITY_ID_FORMAT
+
     def __init__(
         self,
-        hass,
-        device_id,
-        friendly_name,
-        device_class,
-        state_template,
-        icon_template,
-        unique_id,
-        entity_picture_template,
-        availability_template,
-        current_source_template,
-        on_action,
-        off_action,
-        play_action,
-        stop_action,
-        pause_action,
-        next_action,
-        previous_action,
-        volume_up_action,
-        volume_down_action,
-        mute_action,
-        input_templates,
-        title_template,
-        artist_template,
-        album_template,
-        current_volume_template,
-        current_is_muted_template,
-        album_art_template,
-        set_volume_action,
-        play_media_action,
-        media_content_type_template,
-        media_image_url_template,
-        media_image_url_remotely_accessible,
-        media_episode_template,
-        media_season_template,
-        media_series_title_template,
-        media_album_artist_template,
-        seek_action,
-        current_position_template,
-        media_duration_template,
-        sound_mode_templates,
-        current_sound_mode_template,
-    ):
+        hass: HomeAssistant,
+        config: ConfigType,
+        unique_id: str,
+    ) -> None:
         """Initialize the Template Media player."""
-        super().__init__(
-            hass,
-            availability_template=availability_template,
-            icon_template=icon_template,
-            entity_picture_template=entity_picture_template,
+        super().__init__(hass, config, unique_id)
+
+        name = self._attr_name
+
+        self._attr_device_class = config.get(CONF_DEVICE_CLASS)
+        self._template = config[CONF_VALUE_TEMPLATE]
+
+        self._attr_supported_features = MediaPlayerEntityFeature(0)
+        for action_id, supported_feature in (
+            (CONF_ON_ACTION, MediaPlayerEntityFeature.TURN_ON),
+            (CONF_OFF_ACTION, MediaPlayerEntityFeature.TURN_OFF),
+            (CONF_PLAY_ACTION, MediaPlayerEntityFeature.PLAY),
+            (CONF_STOP_ACTION, MediaPlayerEntityFeature.STOP),
+            (CONF_PAUSE_ACTION, MediaPlayerEntityFeature.PAUSE),
+            (CONF_NEXT_ACTION, MediaPlayerEntityFeature.NEXT_TRACK),
+            (CONF_PREVIOUS_ACTION, MediaPlayerEntityFeature.PREVIOUS_TRACK),
+            (CONF_VOLUME_UP_ACTION, MediaPlayerEntityFeature.VOLUME_STEP),
+            (CONF_VOLUME_DOWN_ACTION, MediaPlayerEntityFeature.VOLUME_STEP),
+            (CONF_MUTE_ACTION, MediaPlayerEntityFeature.VOLUME_MUTE),
+            (CONF_SET_VOLUME_ACTION, MediaPlayerEntityFeature.VOLUME_SET),
+            (CONF_PLAY_MEDIA_ACTION, MediaPlayerEntityFeature.PLAY_MEDIA),
+            (CONF_SEEK_ACTION, MediaPlayerEntityFeature.SEEK),
+        ):
+            if (action_config := config.get(action_id)) is not None:
+                self.add_script(action_id, action_config, name, DOMAIN)
+                if supported_feature is not None:
+                    self._attr_supported_features |= supported_feature
+
+        # Source and Source List
+        for action_id, action_config in config.get(CONF_INPUTS, {}).items():
+            if (action_config := config.get(action_id)) is not None:
+                self.add_script(f"input_{action_id}", action_config, name, DOMAIN)
+                self._attr_supported_features |= MediaPlayerEntityFeature.SELECT_SOURCE
+                if self._attr_source_list is None:
+                    self._attr_source_list = []
+                self._attr_source_list.append(action_id)
+
+        # Sound Mode and Sound Mode List
+        for action_id, action_config in config.get(CONF_SOUND_MODES, {}).items():
+            if (action_config := config.get(action_id)) is not None:
+                self.add_script(f"sound_mode_{action_id}", action_config, name, DOMAIN)
+                self._attr_supported_features |= (
+                    MediaPlayerEntityFeature.SELECT_SOUND_MODE
+                )
+                if self._attr_sound_mode_list is None:
+                    self._attr_sound_mode_list = []
+                self._attr_sound_mode_list.append(action_id)
+
+        self._current_source_template = config.get(CONF_CURRENT_SOURCE_TEMPLATE)
+        self._title_template = config.get(CONF_TITLE_TEMPLATE)
+        self._artist_template = config.get(CONF_ARTIST_TEMPLATE)
+        self._album_template = config.get(CONF_ALBUM_TEMPLATE)
+        self._current_volume_template = config.get(CONF_CURRENT_VOLUME_TEMPLATE)
+        self._current_is_muted_template = config.get(CONF_CURRENT_IS_MUTED_TEMPLATE)
+        self._current_sound_mode_template = config.get(CONF_CURRENT_SOUND_MODE_TEMPLATE)
+        self._album_art_template = config.get(CONF_ALBUM_ART_TEMPLATE)
+        self._media_content_type_template = config.get(CONF_MEDIA_CONTENT_TYPE_TEMPLATE)
+        self._media_image_url_template = config.get(CONF_MEDIA_IMAGE_URL_TEMPLATE)
+        self._media_episode_template = config.get(CONF_MEDIA_EPISODE_TEMPLATE)
+        self._media_season_template = config.get(CONF_MEDIA_SEASON_TEMPLATE)
+        self._media_series_title_template = config.get(CONF_MEDIA_SERIES_TITLE_TEMPLATE)
+        self._media_album_artist_template = config.get(CONF_MEDIA_ALBUM_ARTIST_TEMPLATE)
+        self._media_content_type_template = config.get(CONF_MEDIA_CONTENT_TYPE_TEMPLATE)
+        self._current_position_template = config.get(CONF_CURRENT_POSITION_TEMPLATE)
+        self._media_duration_template = config.get(CONF_MEDIA_DURATION_TEMPLATE)
+
+        self._attr_media_image_remotely_accessible = config.get(
+            CONF_MEDIA_IMAGE_URL_REMOTELY_ACCESSIBLE, False
         )
-        self.hass = hass
-        self.entity_id = async_generate_entity_id(
-            ENTITY_ID_FORMAT, device_id, hass=hass
-        )
-        self._name = friendly_name
-        self._device_class = device_class
-        self._template = state_template
-        self._domain = __name__.split(".")[-2]
 
-        self._on_script = None
-        if on_action is not None:
-            self._on_script = Script(hass, on_action, friendly_name, self._domain)
-
-        self._off_script = None
-        if off_action is not None:
-            self._off_script = Script(hass, off_action, friendly_name, self._domain)
-
-        self._play_script = None
-        if play_action is not None:
-            self._play_script = Script(hass, play_action, friendly_name, self._domain)
-
-        self._stop_script = None
-        if stop_action is not None:
-            self._stop_script = Script(hass, stop_action, friendly_name, self._domain)
-
-        self._pause_script = None
-        if pause_action is not None:
-            self._pause_script = Script(hass, pause_action, friendly_name, self._domain)
-
-        self._next_script = None
-        if next_action is not None:
-            self._next_script = Script(hass, next_action, friendly_name, self._domain)
-
-        self._previous_script = None
-        if previous_action is not None:
-            self._previous_script = Script(
-                hass, previous_action, friendly_name, self._domain
-            )
-
-        self._volume_up_script = None
-        if volume_up_action is not None:
-            self._volume_up_script = Script(
-                hass, volume_up_action, friendly_name, self._domain
-            )
-
-        self._volume_down_script = None
-        if volume_down_action is not None:
-            self._volume_down_script = Script(
-                hass, volume_down_action, friendly_name, self._domain
-            )
-
-        self._mute_script = None
-        if mute_action is not None:
-            self._mute_script = Script(hass, mute_action, friendly_name, self._domain)
-
-        self._set_volume_script = None
-        if set_volume_action is not None:
-            self._set_volume_script = Script(
-                hass, set_volume_action, friendly_name, self._domain
-            )
-        self._play_media_script = None
-        if play_media_action is not None:
-            self._play_media_script = Script(
-                hass, play_media_action, friendly_name, self._domain
-            )
-
-        self._seek_script = None
-        if seek_action is not None:
-            self._seek_script = Script(hass, seek_action, friendly_name, self._domain)
-
-        self._state = False
-        self._icon = None
-        self._unique_id = None
-        if unique_id is not None:
-            self._unique_id = unique_id
-        self._entity_picture = None
-        self._available = True
-        self._input_templates = input_templates
-        self._current_source_template = current_source_template
-        self._current_source = None
-        self._source_list = list(input_templates.keys())
-        self._attributes = {}
-        self._title_template = title_template
-        self._artist_template = artist_template
-        self._album_template = album_template
-        self._current_volume_template = current_volume_template
-        self._current_is_muted_template = current_is_muted_template
-        self._album_art_template = album_art_template
-        self._media_content_type_template = media_content_type_template
-        self._media_image_url_template = media_image_url_template
-        self._media_image_url_remotely_accessible = media_image_url_remotely_accessible
-        self._media_episode_template = media_episode_template
-        self._media_season_template = media_season_template
-        self._media_series_title_template = media_series_title_template
-        self._media_album_artist_template = media_album_artist_template
-        self._media_content_type_template = media_content_type_template
-        self._current_position_template = current_position_template
-        self._media_duration_template = media_duration_template
-
-        self._sound_mode_templates = sound_mode_templates
-        self._current_sound_mode_template = current_sound_mode_template
-        self._sound_mode = None
-        self._sound_mode_list = list(sound_mode_templates.keys())
-
-        self._track_name = None
-        self._track_artist = None
-        self._track_album_name = None
-        self._album_art = None
-        self._volume = None
-        self._is_muted = None
-        self._media_image_url = None
-        self._media_episode = None
-        self._media_season = None
-        self._media_series_title = None
-        self._media_album_artist = None
-        self._media_content_type = None
-        self._current_position = None
-        self._media_duration = None
         self._last_update = None
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self.add_template_attribute("_state", self._template, None, self._update_state)
+        self.add_template_attribute(
+            "_attr_state",
+            self._template,
+            None,
+            self._update_state,
+            none_on_template_error=True,
+        )
 
         if self._current_source_template is not None:
             self.add_template_attribute(
-                "_current_source", self._current_source_template
+                "_attr_source",
+                self._current_source_template,
+                None,
+                self._update_source,
+                none_on_template_error=True,
             )
 
         if self._title_template is not None:
-            self.add_template_attribute("_track_name", self._title_template)
+            self.add_template_attribute(
+                "_attr_media_title",
+                self._title_template,
+                cv.string,
+                none_on_template_error=True,
+            )
 
         if self._artist_template is not None:
-            self.add_template_attribute("_track_artist", self._artist_template)
+            self.add_template_attribute(
+                "_attr_media_artist",
+                self._artist_template,
+                cv.string,
+                none_on_template_error=True,
+            )
 
         if self._album_template is not None:
-            self.add_template_attribute("_track_album_name", self._album_template)
+            self.add_template_attribute(
+                "_attr_media_album_name",
+                self._album_template,
+                cv.string,
+                none_on_template_error=True,
+            )
 
         if self._current_volume_template is not None:
-            self.add_template_attribute("_volume", self._current_volume_template)
+            self.add_template_attribute(
+                "_attr_volume_level",
+                self._current_volume_template,
+                cv.positive_float,
+                none_on_template_error=True,
+            )
 
         if self._current_is_muted_template is not None:
-            self.add_template_attribute("_is_muted", self._current_is_muted_template)
+            self.add_template_attribute(
+                "_attr_is_volume_muted",
+                self._current_is_muted_template,
+                cv.boolean,
+            )
 
-        if self._album_art_template is not None:
-            self.add_template_attribute("_album_art", self._album_art_template)
         if self._media_content_type_template is not None:
             self.add_template_attribute(
-                "_media_content_type", self._media_content_type_template
+                "_attr_media_content_type",
+                self._media_content_type_template,
+                None,
+                self._update_media_content_type,
+                none_on_template_error=True,
             )
         if self._media_image_url_template is not None:
             self.add_template_attribute(
-                "_media_image_url", self._media_image_url_template
+                "_attr_media_image_url",
+                self._media_image_url_template,
+                cv.string,
+                none_on_template_error=True,
             )
         if self._media_episode_template is not None:
-            self.add_template_attribute("_media_episode", self._media_episode_template)
+            self.add_template_attribute(
+                "_attr_media_episode",
+                self._media_episode_template,
+                cv.string,
+                none_on_template_error=True,
+            )
         if self._media_season_template is not None:
-            self.add_template_attribute("_media_season", self._media_season_template)
+            self.add_template_attribute(
+                "_attr_media_season",
+                self._media_season_template,
+                cv.string,
+                none_on_template_error=True,
+            )
         if self._media_series_title_template is not None:
             self.add_template_attribute(
-                "_media_series_title", self._media_series_title_template
+                "_attr_media_series_title",
+                self._media_series_title_template,
+                cv.string,
+                none_on_template_error=True,
             )
         if self._media_album_artist_template is not None:
             self.add_template_attribute(
-                "_media_album_artist", self._media_album_artist_template
+                "_attr_media_album_artist",
+                self._media_album_artist_template,
+                cv.string,
+                none_on_template_error=True,
             )
         if self._current_position_template is not None:
             self.add_template_attribute(
-                "_current_position", self._current_position_template
+                "_attr_media_position",
+                self._current_position_template,
+                cv.positive_int,
+                none_on_template_error=True,
             )
         if self._media_duration_template is not None:
             self.add_template_attribute(
-                "_media_duration", self._media_duration_template
+                "_attr_media_duration",
+                self._media_duration_template,
+                cv.positive_int,
+                none_on_template_error=True,
             )
         if self._current_sound_mode_template is not None:
             self.add_template_attribute(
-                "_sound_mode", self._current_sound_mode_template
+                "_attr_sound_mode",
+                self._current_sound_mode_template,
+                None,
+                self._update_sound_mode,
+                none_on_template_error=True,
             )
 
         await super().async_added_to_hass()
@@ -470,362 +357,205 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
     @callback
     def _update_state(self, result):
         super()._update_state(result)
-        self._state = None if isinstance(result, TemplateError) else result
+        if isinstance(result, TemplateError):
+            self._attr_state = None
+            return
 
-    @property
-    def name(self):
-        """Return the name of the media player."""
-        return self._name
+        result = cv.string(result).lower()
+        try:
+            if result == "true":
+                self._attr_state = MediaPlayerState.ON
+            elif result == "false":
+                self._attr_state = MediaPlayerState.OFF
+            else:
+                self._attr_state = MediaPlayerState(result)
+        except ValueError:
+            _LOGGER.error(
+                "Template entity %s received an invalid state %s",
+                self.entity_id,
+                result,
+            )
+            self._attr_state = None
 
-    @property
-    def device_class(self):
-        """Return the class of this device."""
-        return self._device_class
+    @callback
+    def _update_source(self, result):
+        if isinstance(result, TemplateError):
+            self._attr_source = None
+            return
 
-    @property
-    def is_on(self):
-        """Return true if device is on."""
-        return self._state
+        if self._attr_source_list and result in self._attr_source_list:
+            self._attr_source = result
+        else:
+            _LOGGER.warning(
+                "Template entity %s received an invalid source %s",
+                self.entity_id,
+                result,
+            )
 
-    @property
-    def should_poll(self):
-        """Return the polling state."""
-        return False
+    @callback
+    def _update_sound_mode(self, result):
+        if isinstance(result, TemplateError):
+            self._attr_sound_mode = None
+            return
 
-    @property
-    def icon(self):
-        """Return the icon to use in the frontend, if any."""
-        return self._icon
+        if self._attr_sound_mode_list and result in self._attr_sound_mode_list:
+            self._attr_sound_mode = result
+        else:
+            _LOGGER.warning(
+                "Template entity %s received an invalid source %s",
+                self.entity_id,
+                result,
+            )
 
-    @property
-    def supported_features(self):
-        """Flag media player features that are supported."""
+    @callback
+    def _update_media_content_type(self, result):
+        if isinstance(result, TemplateError):
+            self._attr_media_content_type = None
+            return
 
-        support = 0
-        if self._on_script is not None:
-            support |= MediaPlayerEntityFeature.TURN_ON
-        if self._off_script is not None:
-            support |= MediaPlayerEntityFeature.TURN_OFF
-        if self._play_script is not None:
-            support |= MediaPlayerEntityFeature.PLAY
-        if self._stop_script is not None:
-            support |= MediaPlayerEntityFeature.STOP
-        if self._pause_script is not None:
-            support |= MediaPlayerEntityFeature.PAUSE
-        if self._next_script is not None:
-            support |= MediaPlayerEntityFeature.NEXT_TRACK
-        if self._previous_script is not None:
-            support |= MediaPlayerEntityFeature.PREVIOUS_TRACK
-        if self._volume_up_script is not None or self._volume_down_script is not None:
-            support |= MediaPlayerEntityFeature.VOLUME_STEP
-        if self._mute_script is not None:
-            support |= MediaPlayerEntityFeature.VOLUME_MUTE
-        if self._source_list is not None:
-            support |= MediaPlayerEntityFeature.SELECT_SOURCE
-        if self._set_volume_script is not None:
-            support |= MediaPlayerEntityFeature.VOLUME_SET
-        if self._play_media_script is not None:
-            support |= MediaPlayerEntityFeature.PLAY_MEDIA
-        if self._seek_script is not None:
-            support |= MediaPlayerEntityFeature.SEEK
-        if self._sound_mode_list is not None:
-            support |= MediaPlayerEntityFeature.SELECT_SOUND_MODE
-        return support
+        result = cv.string(result).lower()
+        try:
+            self._attr_media_content_type = MediaType(result)
+        except ValueError:
+            _LOGGER.error(
+                "Template entity %s received an invalid media content type %s",
+                self.entity_id,
+                result,
+            )
+            self._attr_media_content_type = None
 
-    @property
-    def available(self) -> bool:
-        """Return if the device is available."""
-        return self._available
+    @callback
+    def _update_media_position(self, result):
+        if isinstance(result, TemplateError):
+            self._attr_media_position_updated_at = None
+            self._attr_media_position = None
+            return
 
-    @property
-    def media_position_updated_at(self):
-        """When was the position of the current playing media valid.
-        Returns value from homeassistant.util.dt.utcnow().
-        """
-        return self._last_update
+        try:
+            if self._attr_state in (MediaPlayerState.PLAYING, MediaPlayerState.PAUSED):
+                self._attr_media_position_updated_at = dt_util.utcnow()
+                self._attr_media_position = cv.positive_int(result)
+            else:
+                self._attr_media_position_updated_at = None
+                self._attr_media_position = None
+        except vol.Invalid:
+            _LOGGER.error(
+                "Template entity %s received an invalid media position %s",
+                self.entity_id,
+                result,
+            )
+            self._attr_media_position_updated_at = None
+            self._attr_media_position = None
+
+    @callback
+    def _update_media_duration(self, result):
+        if isinstance(result, TemplateError):
+            self._attr_media_duration = None
+            return
+
+        try:
+            if self._attr_state in (MediaPlayerState.PLAYING, MediaPlayerState.PAUSED):
+                self._attr_media_duration = cv.positive_int(result)
+            else:
+                self._attr_media_duration = None
+
+        except vol.Invalid:
+            _LOGGER.error(
+                "Template entity %s received an invalid media duration %s",
+                self.entity_id,
+                result,
+            )
+            self._attr_media_duration = None
 
     async def async_turn_on(self):
         """Fire the on action."""
-        await self._on_script.async_run(context=self._context)
+        if script := self._action_scripts.get(CONF_ON_ACTION):
+            await self.async_run_script(script, context=self._context)
 
     async def async_turn_off(self):
         """Fire the off action."""
-        await self._off_script.async_run(context=self._context)
+        if script := self._action_scripts.get(CONF_OFF_ACTION):
+            await self.async_run_script(script, context=self._context)
 
     async def async_volume_up(self):
         """Fire the volume up action."""
-        await self._volume_up_script.async_run(context=self._context)
+        if script := self._action_scripts.get(CONF_VOLUME_UP_ACTION):
+            await self.async_run_script(script, context=self._context)
 
     async def async_volume_down(self):
         """Fire the volume down action."""
-        await self._volume_down_script.async_run(context=self._context)
+        if script := self._action_scripts.get(CONF_VOLUME_DOWN_ACTION):
+            await self.async_run_script(script, context=self._context)
 
     async def async_mute_volume(self, mute):
         """Set the is_muted state."""
         if self._current_is_muted_template is None:
-            self._is_muted = mute
+            self._attr_is_volume_muted = mute
             self.async_write_ha_state()
-        await self._mute_script.async_run({"is_muted": mute}, context=self._context)
+        if script := self._action_scripts.get(CONF_MUTE_ACTION):
+            await self.async_run_script(script, context=self._context)
 
     async def async_media_play(self):
         """Fire the play action."""
-        await self._play_script.async_run(context=self._context)
+        if script := self._action_scripts.get(CONF_PLAY_ACTION):
+            await self.async_run_script(script, context=self._context)
 
     async def async_media_stop(self):
         """Fire the stop action."""
-        await self._stop_script.async_run(context=self._context)
+        if script := self._action_scripts.get(CONF_STOP_ACTION):
+            await self.async_run_script(script, context=self._context)
 
     async def async_media_pause(self):
         """Fire the pause action."""
-        await self._pause_script.async_run(context=self._context)
+        if script := self._action_scripts.get(CONF_PAUSE_ACTION):
+            await self.async_run_script(script, context=self._context)
 
     async def async_media_next_track(self):
         """Fire the media next action."""
-        await self._next_script.async_run(context=self._context)
+        if script := self._action_scripts.get(CONF_NEXT_ACTION):
+            await self.async_run_script(script, context=self._context)
 
     async def async_media_previous_track(self):
         """Fire the media previous action."""
-        await self._previous_script.async_run(context=self._context)
+        if script := self._action_scripts.get(CONF_PREVIOUS_ACTION):
+            await self.async_run_script(script, context=self._context)
 
     async def async_set_volume_level(self, volume):
         """Set the volume."""
         if self._current_volume_template is None:
-            self._volume = volume
+            self._attr_volume_level = volume
             self.async_write_ha_state()
-        await self._set_volume_script.async_run(
-            {"volume": volume}, context=self._context
-        )
+        if script := self._action_scripts.get(CONF_SET_VOLUME_ACTION):
+            await self.async_run_script(script, context=self._context)
 
     async def async_play_media(self, media_type, media_id, **kwargs):
-        """play media"""
-        await self._play_media_script.async_run(
-            {"media_type": media_type, "media_id": media_id}, context=self._context
-        )
+        """Play media."""
+        if script := self._action_scripts.get(CONF_PLAY_MEDIA_ACTION):
+            await self.async_run_script(
+                script,
+                {"media_type": media_type, "media_id": media_id},
+                context=self._context,
+            )
 
     async def async_media_seek(self, position):
         """Send seek command."""
-        await self._seek_script.async_run({"position": position}, context=self._context)
-
-    @property
-    def state(self):
-        """Return the state of the player."""
-        if self._state is None:
-            return None
-        elif self._state == "playing":
-            return MediaPlayerState.PLAYING
-        elif self._state == "paused":
-            return MediaPlayerState.PAUSED
-        elif self._state == "idle":
-            return MediaPlayerState.IDLE
-        elif self._state == "on":
-            return MediaPlayerState.ON
-        elif self._state == "off":
-            return MediaPlayerState.OFF
-        return MediaPlayerState.OFF
-
-    @property
-    def source(self):
-        """Return the current input source."""
-        try:
-            if self._current_source_template is not None:
-                self._current_source = self._current_source_template.async_render()
-            return self._current_source
-        except TemplateError as ex:
-            _LOGGER.error(ex)
-            return None
-
-    @property
-    def source_list(self):
-        """List of available input sources."""
-        return self._source_list
-
-    @property
-    def unique_id(self):
-        """Unique id."""
-        return self._unique_id
-
-    @property
-    def volume_level(self):
-        """Volume level of the media player (0..1)."""
-        return self._volume
-
-    @property
-    def is_volume_muted(self):
-        """Boolean if volume is currently muted."""
-        return self._is_muted
-
-    @property
-    def media_title(self):
-        """Title of current playing media."""
-        return self._track_name
-
-    @property
-    def media_artist(self):
-        """Artist of current playing media, music track only."""
-        return self._track_artist
-
-    @property
-    def media_content_type(self):
-        """Content type of current playing media."""
-        # if self._state == STATE_PLAYING or self._state == STATE_PAUSED:
-        #     return MEDIA_TYPE_MUSIC
-        return self._media_content_type
-
-    @property
-    def media_album_name(self):
-        """Album name of current playing media, music track only."""
-        return self._track_album_name
-
-    @property
-    def media_album_artist(self):
-        return self._media_album_artist
-
-    @property
-    def media_series_title(self):
-        """Return the title of the series of current playing media."""
-        return self._media_series_title
-
-    @property
-    def media_season(self):
-        """Season of current playing media (TV Show only)."""
-        return self._media_season
-
-    @property
-    def media_episode(self):
-        """Episode of current playing media (TV Show only)."""
-        return self._media_episode
-
-    @property
-    def media_image_url(self):
-        return self._media_image_url
-
-    @property
-    def media_image_remotely_accessible(self) -> bool:
-        """If the image url is remotely accessible."""
-        return self._media_image_url_remotely_accessible
-
-    @property
-    def media_position(self):
-        """Position of current playing media in seconds."""
-        if self._state == "playing" or self._state == "paused":
-            self._last_update = dt_util.utcnow()
-            return self._current_position
-        return None
-
-    @property
-    def media_duration(self):
-        if self._state == "playing" or self._state == "paused":
-            return self._media_duration
-        return None
-
-    @property
-    def sound_mode(self):
-        """Return the current input source."""
-        try:
-            if self._current_sound_mode_template is not None:
-                self._sound_mode = self._current_sound_mode_template.async_render()
-            return self._sound_mode
-        except TemplateError as ex:
-            _LOGGER.error(ex)
-            return None
-
-    @property
-    def sound_mode_list(self):
-        """Return a list of available sound modes."""
-        return self._sound_mode_list
+        if script := self._action_scripts.get(CONF_SEEK_ACTION):
+            await self.async_run_script(
+                script, {"position": position}, context=self._context
+            )
 
     async def async_select_source(self, source):
         """Set the input source."""
-        if source in self._input_templates:
-            source_script = Script(
-                self.hass, self._input_templates[source], self._name, self._domain
-            )
+        if script := self._action_scripts.get(f"input_{source}"):
             if self._current_source_template is None:
-                self._current_source = source
+                self._attr_source = source
                 self.async_write_ha_state()
-            await source_script.async_run(context=self._context)
+            await self.async_run_script(script, context=self._context)
 
     async def async_select_sound_mode(self, sound_mode):
         """Select sound mode."""
-        if sound_mode in self._sound_mode_templates:
-            sound_mode_script = Script(
-                self.hass,
-                self._sound_mode_templates[sound_mode],
-                self._name,
-                self._domain,
-            )
+        if script := self._action_scripts.get(f"sound_mode_{sound_mode}"):
             if self._current_sound_mode_template is None:
-                self._sound_mode = sound_mode
+                self._attr_sound_mode = sound_mode
                 self.async_write_ha_state()
-            await sound_mode_script.async_run(context=self._context)
-
-    async def async_update(self):
-        """Update the state from the template."""
-
-        try:
-            state = self._template.async_render().lower()
-
-            if state in _VALID_STATES:
-                self._state = state
-            elif state == STATE_UNKNOWN:
-                self._state = None
-            else:
-                _LOGGER.error(
-                    "Received invalid media_player state: %s. Expected: %s.",
-                    state,
-                    ", ".join(_VALID_STATES),
-                )
-                self._state = None
-
-        except TemplateError as ex:
-            _LOGGER.error(ex)
-            self._state = None
-
-        for property_name, template in (
-            ("_icon", self._icon_template),
-            ("_entity_picture", self._entity_picture_template),
-            ("_available", self._availability_template),
-            ("_volume", self._current_volume_template),
-            ("_is_muted", self._current_is_muted_template),
-            ("_track_name", self._title_template),
-            ("_track_artist", self._artist_template),
-            ("_track_album_name", self._album_template),
-            ("_album_art", self._album_art_template),
-            ("_current_positon", self._current_position),
-            ("_media_duration", self._media_duration),
-        ):
-            if template is None:
-                continue
-
-            try:
-                value = template.async_render()
-                if property_name == "_available":
-                    value = value.lower() == "true"
-                if (
-                    property_name == "_current_positon"
-                    and value != self._current_position
-                ):
-                    self._last_update = dt_util.utcnow()
-                setattr(self, property_name, value)
-            except TemplateError as ex:
-                friendly_property_name = property_name[1:].replace("_", " ")
-                if ex.args and ex.args[0].startswith(
-                    "UndefinedError: 'None' has no attribute"
-                ):
-                    # Common during HA startup - so just a warning
-                    _LOGGER.warning(
-                        "Could not render %s template %s, the state is unknown.",
-                        friendly_property_name,
-                        self._name,
-                    )
-                    return
-
-                try:
-                    setattr(self, property_name, getattr(super(), property_name))
-                except AttributeError:
-                    _LOGGER.error(
-                        "Could not render %s template %s: %s",
-                        friendly_property_name,
-                        self._name,
-                        ex,
-                    )
+            await self.async_run_script(script, context=self._context)

--- a/custom_components/media_player_template/media_player.py
+++ b/custom_components/media_player_template/media_player.py
@@ -376,9 +376,10 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
                 self._attr_state = MediaPlayerState(result)
         except ValueError:
             _LOGGER.error(
-                "Template entity %s received an invalid state %s",
+                "Template entity %s received an invalid state %s, expected: true, false, %s",
                 self.entity_id,
                 result,
+                ", ".join(MediaPlayerState),
             )
             self._attr_state = None
 
@@ -392,9 +393,10 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
             self._attr_source = result
         else:
             _LOGGER.warning(
-                "Template entity %s received an invalid source %s",
+                "Template entity %s received an invalid source %s, expected: %s",
                 self.entity_id,
                 result,
+                ", ".join(self._attr_source_list),
             )
 
     @callback
@@ -407,9 +409,10 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
             self._attr_sound_mode = result
         else:
             _LOGGER.warning(
-                "Template entity %s received an invalid source %s",
+                "Template entity %s received an invalid media sound mode %s, expected: %s",
                 self.entity_id,
                 result,
+                ", ".join(self._attr_sound_mode_list),
             )
 
     @callback
@@ -423,9 +426,10 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
             self._attr_media_content_type = MediaType(result)
         except ValueError:
             _LOGGER.error(
-                "Template entity %s received an invalid media content type %s",
+                "Template entity %s received an invalid media content type %s, expected: %s",
                 self.entity_id,
                 result,
+                ", ".join(MediaType),
             )
             self._attr_media_content_type = None
 

--- a/custom_components/media_player_template/media_player.py
+++ b/custom_components/media_player_template/media_player.py
@@ -226,8 +226,6 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
             CONF_MEDIA_IMAGE_URL_REMOTELY_ACCESSIBLE, False
         )
 
-        self._last_update = None
-
     async def async_added_to_hass(self):
         """Register callbacks."""
         self.add_template_attribute(

--- a/custom_components/media_player_template/media_player.py
+++ b/custom_components/media_player_template/media_player.py
@@ -536,7 +536,9 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
             self.async_write_ha_state()
         if script := self._action_scripts.get(CONF_SET_VOLUME_ACTION):
             await self.async_run_script(
-                script, {"volume": volume}, context=self._context
+                script,
+                run_variables={"volume": volume},
+                context=self._context,
             )
 
     async def async_play_media(self, media_type, media_id, **kwargs):
@@ -544,7 +546,7 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
         if script := self._action_scripts.get(CONF_PLAY_MEDIA_ACTION):
             await self.async_run_script(
                 script,
-                {"media_type": media_type, "media_id": media_id},
+                run_variables={"media_type": media_type, "media_id": media_id},
                 context=self._context,
             )
 
@@ -552,7 +554,9 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
         """Send seek command."""
         if script := self._action_scripts.get(CONF_SEEK_ACTION):
             await self.async_run_script(
-                script, {"position": position}, context=self._context
+                script,
+                run_variables={"position": position},
+                context=self._context,
             )
 
     async def async_select_source(self, source):

--- a/custom_components/media_player_template/media_player.py
+++ b/custom_components/media_player_template/media_player.py
@@ -42,6 +42,10 @@ import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
+LEGACY_FIELDS = {
+    CONF_VALUE_TEMPLATE: CONF_STATE,
+}
+
 CONF_ALBUM_ART_TEMPLATE = "album_art_template"
 CONF_ALBUM_TEMPLATE = "album_template"
 CONF_ARTIST_TEMPLATE = "artist_template"
@@ -141,7 +145,8 @@ async def async_setup_platform(
         None,
         async_add_entities,
         discovery_info,
-        {},
+        LEGACY_FIELDS,
+        CONF_MEDIAPLAYER,
     )
 
 

--- a/custom_components/media_player_template/media_player.py
+++ b/custom_components/media_player_template/media_player.py
@@ -535,7 +535,9 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
             self._attr_volume_level = volume
             self.async_write_ha_state()
         if script := self._action_scripts.get(CONF_SET_VOLUME_ACTION):
-            await self.async_run_script(script, context=self._context)
+            await self.async_run_script(
+                script, {"volume": volume}, context=self._context
+            )
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Play media."""

--- a/custom_components/media_player_template/media_player.py
+++ b/custom_components/media_player_template/media_player.py
@@ -192,24 +192,24 @@ class MediaPlayerTemplate(TemplateEntity, MediaPlayerEntity):
                     self._attr_supported_features |= supported_feature
 
         # Source and Source List
-        for action_id, action_config in config.get(CONF_INPUTS, {}).items():
-            if (action_config := config.get(action_id)) is not None:
-                self.add_script(f"input_{action_id}", action_config, name, DOMAIN)
-                self._attr_supported_features |= MediaPlayerEntityFeature.SELECT_SOURCE
-                if self._attr_source_list is None:
-                    self._attr_source_list = []
-                self._attr_source_list.append(action_id)
+        for input_id, input_config in config.get(CONF_INPUTS, {}).items():
+            self.add_script(f"input_{input_id}", input_config, name, DOMAIN)
+            self._attr_supported_features |= MediaPlayerEntityFeature.SELECT_SOURCE
+            if self._attr_source_list is None:
+                self._attr_source_list = []
+            self._attr_source_list.append(input_id)
 
         # Sound Mode and Sound Mode List
-        for action_id, action_config in config.get(CONF_SOUND_MODES, {}).items():
-            if (action_config := config.get(action_id)) is not None:
-                self.add_script(f"sound_mode_{action_id}", action_config, name, DOMAIN)
-                self._attr_supported_features |= (
-                    MediaPlayerEntityFeature.SELECT_SOUND_MODE
-                )
-                if self._attr_sound_mode_list is None:
-                    self._attr_sound_mode_list = []
-                self._attr_sound_mode_list.append(action_id)
+        for sound_mode_id, sound_mode_config in config.get(
+            CONF_SOUND_MODES, {}
+        ).items():
+            self.add_script(
+                f"sound_mode_{sound_mode_id}", sound_mode_config, name, DOMAIN
+            )
+            self._attr_supported_features |= MediaPlayerEntityFeature.SELECT_SOUND_MODE
+            if self._attr_sound_mode_list is None:
+                self._attr_sound_mode_list = []
+            self._attr_sound_mode_list.append(sound_mode_id)
 
         self._current_source_template = config.get(CONF_CURRENT_SOURCE_TEMPLATE)
         self._title_template = config.get(CONF_TITLE_TEMPLATE)


### PR DESCRIPTION
This makes use of all the recent changes in the integration.

Some clarifications here:

1.  CONF_ALBUM_ART_TEMPLATE does nothing.  Users should be using CONF_ENTITY_PICTURE_TEMPLATE
2.  ATTR_ENTITY_ID was deprecated upstream almost 5 years ago.  It also does nothing.

I kept both of them in to avoid breaking configurations.

There may be some unforseen behavior changes because the previous version of this integration had outdated ways of updating states.

This new code heavily relies on the upstream MediaPlayer entity to handle all the heavy lifting.  Because of that, we are using the under the hood attributes to set all properties on the object.  This should provide a better user experience with the entity but it may change behavior.

Some new behavior is inherently added as well:

1.  `this` will work in all scripts.
2. `friendly_name` now accepts templates
3. availability behavior will now be consistent with all other template entities.
4. You can now set the state to `None` and the entity will go `unknown`.

In regards to development benefits;
1.  Optimistic states can be added rather easily.
2. New scripts/templates would be easy to add without heavy changes.